### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "gh-pages": "^2.0.1",
     "install": "^0.12.2",
-    "npm": "^6.9.0",
     "react": "^16.6.0",
     "react-bootstrap": "^0.32.4",
     "react-dom": "^16.6.0",


### PR DESCRIPTION

Hello ThiagoAlbertinoAssis!

It seems like you have npm as one of your (dev-) dependency in thiagoalbertinoassis.github.io.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
